### PR TITLE
fetch_rapids.cmake: redef ENV{RAPIDS_CMAKE_BRANCH}

### DIFF
--- a/fetch_rapids.cmake
+++ b/fetch_rapids.cmake
@@ -1,6 +1,5 @@
 # =============================================================================
 # Copyright (c) 2023, NVIDIA CORPORATION.
-# Modifications Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -12,35 +11,38 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 # =============================================================================
-
-# Modifications Copyright (c) 2024 Advanced Micro Devices, Inc.
+# Modifications Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
 
 if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/RMM_RAPIDS.cmake)
-  if (DEFINED ENV{RAPIDS_CMAKE_BRANCH})
-    set(RAPIDS_CMAKE_BRANCH "$ENV{RAPIDS_CMAKE_BRANCH}")
+  if(DEFINED ENV{RAPIDS_CMAKE_SCRIPT_BRANCH})
+    set(RAPIDS_CMAKE_SCRIPT_BRANCH "$ENV{RAPIDS_CMAKE_SCRIPT_BRANCH}")
   else()
-    set(RAPIDS_CMAKE_BRANCH branch-24.06)
+    set(RAPIDS_CMAKE_SCRIPT_BRANCH branch-24.06)
   endif()
 
-  set(URL "https://raw.githubusercontent.com/ROCm/rapids-cmake/${RAPIDS_CMAKE_BRANCH}/RAPIDS.cmake")
+  set(URL "https://raw.githubusercontent.com/ROCm/rapids-cmake/${RAPIDS_CMAKE_SCRIPT_BRANCH}/RAPIDS.cmake")
   file(DOWNLOAD ${URL}
-       ${CMAKE_CURRENT_BINARY_DIR}/RMM_RAPIDS.cmake
-       STATUS DOWNLOAD_STATUS
+    ${CMAKE_CURRENT_BINARY_DIR}/RMM_RAPIDS.cmake
+    STATUS DOWNLOAD_STATUS
   )
   list(GET DOWNLOAD_STATUS 0 STATUS_CODE)
   list(GET DOWNLOAD_STATUS 1 ERROR_MESSAGE)
@@ -53,4 +55,9 @@ if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/RMM_RAPIDS.cmake)
     message(FATAL_ERROR "Failed to download 'RMM_RAPIDS.cmake'. Reason: ${ERROR_MESSAGE}")
   endif()
 endif()
+
+if(DEFINED ENV{RAPIDS_CMAKE_BRANCH})
+  set(rapids-cmake-branch $ENV{RAPIDS_CMAKE_BRANCH})
+endif()
+
 include(${CMAKE_CURRENT_BINARY_DIR}/RMM_RAPIDS.cmake)


### PR DESCRIPTION
* Introduces new variable RAPIDS_CMAKE_SCRIPT_BRANCH (env + cmake var) for specifying where to fetch the RAPIDS.cmake script from.
* Repurpose RAPIDS_CMAKE_BRANCH environment variable for specfiying what ROCm/rapids-cmake branch shall be checked out by the RAPIDS.cmake script. This var overrides CMake var `rapids-cmake-branch`.

# TODO

* [x] Test effect via CI script.